### PR TITLE
Added swap partition config to fix memory issue

### DIFF
--- a/.ebextensions/03_swap_setup.config
+++ b/.ebextensions/03_swap_setup.config
@@ -1,0 +1,3 @@
+container_commands:
+  swap_setup:
+    command: "bash .ebextensions/setup_swap.sh"

--- a/.ebextensions/setup_swap.sh
+++ b/.ebextensions/setup_swap.sh
@@ -4,7 +4,7 @@ SWAPFILE=/var/swapfile
 SWAP_MEGABYTES=2048
 
 if [ -f $SWAPFILE ]; then
-  echo "Swapfile $SWAPFILE found; swap congiguration already exists"
+  echo "Swapfile $SWAPFILE found; swap space configuration already exists"
   exit;
 fi
 

--- a/.ebextensions/setup_swap.sh
+++ b/.ebextensions/setup_swap.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+SWAPFILE=/var/swapfile
+SWAP_MEGABYTES=2048
+
+if [ -f $SWAPFILE ]; then
+  echo "Swapfile $SWAPFILE found; swap congiguration already exists"
+  exit;
+fi
+
+/bin/dd if=/dev/zero of=$SWAPFILE bs=1M count=$SWAP_MEGABYTES
+/bin/chmod 600 $SWAPFILE
+/sbin/mkswap $SWAPFILE
+/sbin/swapon $SWAPFILE


### PR DESCRIPTION
This PR solves the issue encountered when Travis deployed a new version of the Application. **The issue has nothing to do with Travis.**

Travis helped us see what happens behind the scenes when a new EB environment deploys a new version of the application. Essentially, when the app runs `npm install --production` -- it randomly fails due to low-memory. This error occurs and was found in `/node_js/npm-debug.log`:

```
226591 error argv "/opt/elasticbeanstalk/node-install/node-v6.11.5-linux-x64/bin/node" "/opt/elasticbeanstalk/node-install/node-v6.11.5-linux-x64/bin/npm" "--production" "install"
226592 error node v6.11.5
226593 error npm  v3.10.10
226594 error code ENOMEM
226595 error errno ENOMEM
````

By adding swap_space configuration, the EB will allocate new space and thus fix the issue.

see: http://steinn.org/post/elasticbeanstalk-swap/
