### PR TITLE
Bump footer to v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+### v1.7.8
+- Updating @nypl/dgx-react-footer to 0.5.2.
+
 ### v1.7.7
 - Updating @nypl/dgx-header-component to 2.4.19
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NYPL New Arrivals
 
 ## Version
-> v1.7.7
+> v1.7.8
 
 A React/Node Universal JavaScript Application focused on displaying bib items that are new arrivals or on order at NYPL.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-new-arrivals",
-  "version": "1.7.7",
+  "version": "1.7.8",
   "description": "NYPL New Arrivals",
   "main": "index.js",
   "scripts": {
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@nypl/dgx-header-component": "2.4.19",
-    "@nypl/dgx-react-footer": "0.5.1",
+    "@nypl/dgx-react-footer": "0.5.2",
     "alt": "0.18.2",
     "axios": "0.9.1",
     "babel": "6.5.2",


### PR DESCRIPTION
This PR updates footer to v0.5.2 to add non-profit status information

https://jira.nypl.org/browse/SCC-1309