### PR TITLE
SEB-1379 Adding Falcon sensor to operating system.

### DIFF
--- a/.ebextensions/falcon_crowdstrike.config
+++ b/.ebextensions/falcon_crowdstrike.config
@@ -1,0 +1,12 @@
+files:
+  "/opt/elasticbeanstalk/hooks/appdeploy/pre/07_falcon_crowdstrike.sh":
+    mode: "000755"
+    owner: ec2-user
+    group: ec2-user
+    content: |
+      #!/usr/bin/env bash
+      . /opt/elasticbeanstalk/support/envvars
+      cd /home/ec2-user
+      wget http://yumrepo.aws.nypl.org/nypl-yum/rpm/x86_64/falcon-sensor-3.8.0-3902.amzn1.x86_64.rpm
+      yum -y install /home/ec2-user/falcon-sensor-3.8.0-3902.amzn1.x86_64.rpm
+    encoding: plain


### PR DESCRIPTION
### What is Falcon Crowdstrike?
Two words: Intrusion Detection

### How does it work?
A copy of Falcon sensor would be installed on Elastic Beanstalk instances or on cluster level of ECS Clusters. After installation, a falcon-sensor agent runs in the background detecting threats on the instance. Any threats detected will be available on the Falcon management console. 

For the case of Elastic Beanstalk, since autoscaling would create new instances and destroy old instances, the installation process needs to be part of .ebextensions to ensure Falcon sensor is installed on every instance creation, hence the code addition and pull requests.

### Acceptance Criteria
Instances can be seen on Falcon management console after code deployment.

### QA Work Required? 
No QA work required, but I need to know when it is okay to push the changes to QA servers and not be in the way of QA work.

### Which applications are affected by this?
For the first round, I am putting Falcon sensor on front-facing Node apps except the Header, which would probably need extensive coordination. I will generate a list of applications affected by this change. A preliminary applications list is of the following:

- Global Search
- Get A Library Card Form
- Blogs Beta
- Booklists
- Locations
- New Arrivals
- Staff Picks
- Homepage

### References

- [CrowdStrike Falcon FAQ](https://www.crowdstrike.com/endpoint-security-products/crowdstrike-falcon-faq/)
- [Advanced Endpoint Protection for Amazon EC2](https://www.crowdstrike.com/partners/aws-endpoint-protection/) 