### PR TITLE
Update header to 2.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+### v1.7.12
+- Updating @nypl/dgx-header-component to 2.5.8
+
 ### v1.7.11
 - Updating @nypl/dgx-header-component to 2.5.6
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NYPL New Arrivals
 
 ## Version
-> v1.7.11
+> v1.7.12
 
 A React/Node Universal JavaScript Application focused on displaying bib items that are new arrivals or on order at NYPL.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-new-arrivals",
-  "version": "1.7.11",
+  "version": "1.7.12",
   "description": "NYPL New Arrivals",
   "main": "index.js",
   "scripts": {
@@ -34,7 +34,7 @@
     "react-hot-loader": "1.2.8"
   },
   "dependencies": {
-    "@nypl/dgx-header-component": "2.5.6",
+    "@nypl/dgx-header-component": "2.5.8",
     "@nypl/dgx-react-footer": "0.5.2",
     "alt": "0.18.2",
     "axios": "0.9.1",


### PR DESCRIPTION
Update header to 2.5.8 to incorporate [login/logout fixes](https://github.com/NYPL/dgx-header-component/pull/79).