### PR TITLE
RENO-1153: Update deprecated node-sass; update dgx-react-footer to 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## CHANGELOG
 
+### v1.7.14
+- Updating node-sass to 4.13.1
+- Updating @nypl/dgx-react-footer to 0.5.4.
+- Remove old Bitbucket deprecation notice from README.
+
 ### v1.7.13
 - Updating @nypl/dgx-header-component to 2.6.0
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NYPL New Arrivals
 
 ## Version
-> v1.7.13
+> v1.7.14
 
 A React/Node Universal JavaScript Application focused on displaying bib items that are new arrivals or on order at NYPL.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-new-arrivals",
-  "version": "1.7.13",
+  "version": "1.7.14",
   "description": "NYPL New Arrivals",
   "main": "index.js",
   "scripts": {
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@nypl/dgx-header-component": "2.6.0",
-    "@nypl/dgx-react-footer": "0.5.2",
+    "@nypl/dgx-react-footer": "0.5.4",
     "alt": "0.18.2",
     "axios": "0.9.1",
     "babel": "6.5.2",
@@ -67,7 +67,7 @@
     "iso": "5.1.0",
     "jsdom": "9.4.2",
     "jsonapi-parserinator": "0.5.0",
-    "node-sass": "3.4.0",
+    "node-sass": "4.13.1",
     "prop-types": "15.5.10",
     "react": "15.5.4",
     "react-a11y": "0.3.3",


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-1153)

**This PR does the following:**

- Updates node-sass to v4.13.1 to be compatible with modern versions of node
- Updates dgx-react-footer to v0.5.4
- The footer update removes the Kievit font, Tumbler icon, and adds [system-font-css](https://github.com/jonathantneal/system-font-css) according to this [migration guide](https://docs.google.com/document/d/1gErDfbmTuKvSUkmfFnhRh9BAF1CCqUl66koTAtOZmdU/edit#)