### PR TITLE
RENO-1153 Update dgx-react-footer to 0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+### v1.7.15
+- Updating @nypl/dgx-react-footer to 0.5.5.
+
 ### v1.7.14
 - Updating node-sass to 4.13.1
 - Updating @nypl/dgx-react-footer to 0.5.4.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NYPL New Arrivals
 
 ## Version
-> v1.7.14
+> v1.7.15
 
 A React/Node Universal JavaScript Application focused on displaying bib items that are new arrivals or on order at NYPL.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-new-arrivals",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "description": "NYPL New Arrivals",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@nypl/dgx-header-component": "2.6.0",
-    "@nypl/dgx-react-footer": "0.5.4",
+    "@nypl/dgx-react-footer": "0.5.5",
     "alt": "0.18.2",
     "axios": "0.9.1",
     "babel": "6.5.2",


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-1153)

**This PR does the following:**

- Updates dgx-react-footer to v0.5.5