### PR TITLE
RENO-1275: update dgx-react-footer to 0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+### v1.7.16
+- Updating @nypl/dgx-react-footer to 0.5.6.
+
 ### v1.7.15
 - Updating @nypl/dgx-react-footer to 0.5.5.
 - Updating Falcon Crowdstrike to 5.29.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NYPL New Arrivals
 
 ## Version
-> v1.7.15
+> v1.7.16
 
 A React/Node Universal JavaScript Application focused on displaying bib items that are new arrivals or on order at NYPL.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-new-arrivals",
-  "version": "1.7.15",
+  "version": "1.7.16",
   "description": "NYPL New Arrivals",
   "main": "index.js",
   "scripts": {
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@nypl/dgx-header-component": "2.6.0",
-    "@nypl/dgx-react-footer": "0.5.5",
+    "@nypl/dgx-react-footer": "0.5.6",
     "alt": "0.18.2",
     "axios": "0.9.1",
     "babel": "6.5.2",

--- a/server.js
+++ b/server.js
@@ -75,7 +75,7 @@ const server = app.listen(app.get('port'), (error) => {
   console.log(colors.yellow.underline(appConfig.appName));
   console.log(
     colors.green('Express server is listening at'),
-    colors.cyan(`localhost: ${app.get('port')}`)
+    colors.cyan(`http://localhost:${app.get('port')}`)
   );
 });
 


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-1275)

**This PR does the following:**

- Updates dgx-react-footer to v0.5.6