### PR TITLE
RENO-1829: Update dgx-header-component to 2.7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '6'
+- '10'
 cache:
   directories:
   - node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+### v1.7.17
+- Updating @nypl/dgx-header-component to 2.7.1.
+
 ### v1.7.16
 - Updating @nypl/dgx-react-footer to 0.5.6.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NYPL New Arrivals
 
 ## Version
-> v1.7.16
+> v1.7.17
 
 A React/Node Universal JavaScript Application focused on displaying bib items that are new arrivals or on order at NYPL.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dgx-new-arrivals",
-  "version": "1.7.16",
+  "version": "1.7.17",
   "description": "NYPL New Arrivals",
   "main": "index.js",
   "scripts": {
@@ -34,7 +34,7 @@
     "react-hot-loader": "1.2.8"
   },
   "dependencies": {
-    "@nypl/dgx-header-component": "2.6.0",
+    "@nypl/dgx-header-component": "2.7.1",
     "@nypl/dgx-react-footer": "0.5.6",
     "alt": "0.18.2",
     "axios": "0.9.1",


### PR DESCRIPTION
[Related Jira ticket](https://jira.nypl.org/browse/RENO-1829)

**This PR does the following:**

- Updates dgx-header-component to v2.7.1

This update adds the text centering to the global messaging.